### PR TITLE
Limit the height of the body container to 100% of the viewport height on Stoplight Elements page.

### DIFF
--- a/src/openapipages/elements.py
+++ b/src/openapipages/elements.py
@@ -53,7 +53,7 @@ class Elements(Base):
                 {head_css_str}
                 {head_js_str}
             </head>
-            <body>
+            <body style="height: 100vh;">
                 <noscript>
                     Stoplight Elements requires Javascript to function. Please enable it to browse the documentation.
                 </noscript>

--- a/src/openapipages/elements.py
+++ b/src/openapipages/elements.py
@@ -52,8 +52,13 @@ class Elements(Base):
                 <link rel="shortcut icon" href="{favicon_url}">
                 {head_css_str}
                 {head_js_str}
+                <style>
+                    body {{
+                        height: 100vh;
+                    }}
+                </style>
             </head>
-            <body style="height: 100vh;">
+            <body>
                 <noscript>
                     Stoplight Elements requires Javascript to function. Please enable it to browse the documentation.
                 </noscript>


### PR DESCRIPTION
Thank you for the fantastic work has done. When I saw the screenshot, I noticed that the Stoplight doc page does not display correctly. I have encountered this problem before.
![image](https://github.com/danielgtaylor/huma/assets/5282978/cf060a9c-2067-4811-8cdd-eb562225b285)

I found a solution on the Stoplight documentation website that suggests resolving the issue by adding a style configuration to the body.
```html
<body style="height: 100vh;">
    <stoplight-api />
</body>
```
[Stoplight Layout](https://docs.stoplight.io/docs/elements/d536b917a4e1d-layout)

Hope this issue can be fixed!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
	- Updated the app's page layout to ensure full viewport height coverage for a more immersive user experience.
	- Added a style attribute to set the height of the <body> tag to 100vh in the `get_html_template` method of `elements.py`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->