### PR TITLE
Release 0.1.1

### DIFF
--- a/src/openapipages/__about__.py
+++ b/src/openapipages/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
# Fixed

* [Limit the height of the body container to 100% of the viewport height on the Stoplight Elements page by mailbaoer · Pull Request #12 · hasansezertasan/openapipages](https://github.com/hasansezertasan/openapipages/pull/12)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the application version number to 0.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->