### PR TITLE
Disabled the built-in `/redoc` page in FastAPI to allow for the creation of a custom documentation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 from openapipages import Elements, RapiDoc, ReDoc, Scalar, SwaggerUI
 
-app = FastAPI()
+# Disable the built-in /redoc page so we can make a custom one.
+app = FastAPI(redoc_url=None)
 
 
 @app.get("/")

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -3,7 +3,8 @@ from fastapi.responses import HTMLResponse
 from openapipages import Elements, RapiDoc, ReDoc, Scalar, SwaggerUI
 from typing_extensions import Dict
 
-app = FastAPI()
+# Disable the built-in /redoc page so we can make a custom one.
+app = FastAPI(redoc_url=None)
 
 
 @app.get("/")


### PR DESCRIPTION
In the current version of the fastapi example our custom /redoc page is not used. The built-in page takes precedence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Disabled the built-in `/redoc` page in FastAPI to allow for the creation of a custom documentation page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->