### PR TITLE
Pass ReDoc UI Parameters using the JavaScript API instead of HTML Tags

### DIFF
--- a/src/openapipages/redoc.py
+++ b/src/openapipages/redoc.py
@@ -19,7 +19,7 @@ default_parameters: Annotated[
     "theme": {
         "typography": {"code": {"wrap": True}},
     },
-    "hide-download-button": False,
+    "hideDownloadButton": False,
 }
 
 
@@ -35,7 +35,7 @@ class ReDoc(Base):
             It is normally set to a CDN URL.
             """
         ),
-    ] = "https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"
+    ] = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js"
     with_google_fonts: Annotated[
         bool,
         Doc(
@@ -64,15 +64,6 @@ class ReDoc(Base):
         current_redoc_ui_parameters = default_parameters.copy()
         current_redoc_ui_parameters.update(self.ui_parameters or {})
 
-        def add_redoc_ui_parameters() -> str:
-            _props = ""
-            for key, value in current_redoc_ui_parameters.items():
-                if value:
-                    _props += f"{key}='{json.dumps(value)}' "
-                else:
-                    _props += f"{key} "
-            return _props
-
         html_template = self.get_html_template()
         return html_template.format(
             title=self.title,
@@ -82,7 +73,7 @@ class ReDoc(Base):
             head_js_str=self.get_head_js_str(),
             tail_js_str=self.get_tail_js_str(),
             google_fonts_str=google_fonts_str,
-            redoc_ui_parameters=add_redoc_ui_parameters(),
+            redoc_ui_parameters=json.dumps(current_redoc_ui_parameters, indent=2),
         )
 
     def get_html_template(self) -> str:
@@ -109,8 +100,15 @@ class ReDoc(Base):
                 <noscript>
                     ReDoc requires Javascript to function. Please enable it to browse the documentation.
                 </noscript>
-                <redoc spec-url="{openapi_url}" {redoc_ui_parameters}></redoc>
+                <div id="redoc-container"></div>
                 {tail_js_str}
+                <script>
+                  Redoc.init(
+                    "{openapi_url}",
+                    {redoc_ui_parameters},
+                    document.getElementById("redoc-container")
+                  )
+                </script>
             </body>
         </html>
         """

--- a/tests/test_redoc.py
+++ b/tests/test_redoc.py
@@ -11,7 +11,8 @@ async def test_redoc_plain() -> None:
         response = await client.get("/redoc-plain")
         assert response.status_code == 200, response.text
         assert response.headers["content-type"] == "text/html; charset=utf-8"
-        assert "redoc@next" in response.text
+        assert "redoc@2" in response.text
+        assert '"hideDownloadButton": false' in response.text
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
Currently passing redoc UI parameters has the following issues:
* It puts json-ed values of parameters in single quotes, which breaks if the value itself contains single quotes.
* If the value is falsy, only the name of the parameter is used. This syntax is *not* treated as falsy by redoc.

The latter causes the download button to be always hidden, because the default parameters have "hide-download-button": False. There is no way to un-hide it with the current code.

Change this to use the javascript API to pass UI parameters[1], which is much simpler and more robust.

Also, stop using the "next" version of redoc, as suggested here[2]. This was an old release candidate for version 2. Use the officially released version 2.

[1] https://redocly.com/docs/redoc/deployment/html/#the-redoc-object
[2] https://github.com/tiangolo/fastapi/pull/9700

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes issues with passing Redoc UI parameters by using the JavaScript API and updates the Redoc version to the officially released version 2. It also includes updates to the tests to ensure the changes are correctly implemented.

* **Bug Fixes**:
    - Fixed issue with passing Redoc UI parameters where JSON values were incorrectly wrapped in single quotes, causing errors if the value contained single quotes.
    - Resolved issue where falsy values for Redoc UI parameters were not correctly handled, leading to the download button being always hidden.
* **Enhancements**:
    - Updated the method of passing Redoc UI parameters to use the JavaScript API for improved robustness and simplicity.
    - Replaced the usage of the 'next' version of Redoc with the officially released version 2.
* **Tests**:
    - Updated tests to verify the correct version of Redoc is used and that the 'hideDownloadButton' parameter is correctly set.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where the Redoc download button configuration was not properly recognized by renaming the key to `hideDownloadButton`.

- **Improvements**
  - Updated the Redoc CDN URL to improve stability and ensure compatibility with the latest version.
  - Enhanced the handling of UI parameters for Redoc, ensuring more reliable rendering.

- **Tests**
  - Updated test cases to verify changes in Redoc configurations and ensure correct initialization of the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->