### PR TITLE
docs(README.md): redirect to litestar example on usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,48 +123,7 @@ def get_rapidoc() -> str:
 
 ### Litestar
 
-> The `include_in_schema` parameter is set to `False` in each endpoint to avoid including these endpoints in the OpenAPI Spec.
-
-```python
-from litestar import Litestar, MediaType, get
-from openapipages import Elements, RapiDoc, ReDoc, Scalar, SwaggerUI
-
-openapi_url = "/schema/openapi.json"
-
-
-@get("/")
-def root() -> dict[str, str]:
-    return {"Hello": "World"}
-
-
-@get("/swaggerui", media_type=MediaType.HTML, include_in_schema=False)
-def get_swaggerui() -> str:
-    return SwaggerUI(title="Swagger UI", openapi_url=openapi_url).render()
-
-
-@get("/redoc", media_type=MediaType.HTML, include_in_schema=False)
-def get_redoc() -> str:
-    return ReDoc(title="ReDoc", openapi_url=openapi_url).render()
-
-
-@get("/scalar", media_type=MediaType.HTML, include_in_schema=False)
-def get_scalar() -> str:
-    return Scalar(title="Scalar", openapi_url=openapi_url).render()
-
-
-@get("/elements", media_type=MediaType.HTML, include_in_schema=False)
-def get_elements() -> str:
-    return Elements(title="Elements", openapi_url=openapi_url).render()
-
-
-@get("/rapidoc", media_type=MediaType.HTML, include_in_schema=False)
-def get_rapidoc() -> str:
-    return RapiDoc(title="RapiDoc", openapi_url=openapi_url).render()
-
-
-app = Litestar([root, get_swaggerui, get_redoc, get_scalar, get_elements, get_rapidoc])
-
-```
+See the [Litestar Example](examples/litestar/README.md) for more details.
 
 ## Motivation
 

--- a/examples/fastapi/README.md
+++ b/examples/fastapi/README.md
@@ -1,6 +1,6 @@
 # FastAPI Example
 
-This example shows how to integrate [FastAPI](https://github.com/fastapi/fastapi/) with [openapipages](https://github.com/hasansezertasan/openapipages)
+This example shows how to integrate [FastAPI](https://github.com/fastapi/fastapi/) with [openapipages](https://github.com/hasansezertasan/openapipages).
 
 ## How to run this example
 

--- a/examples/litestar/README.md
+++ b/examples/litestar/README.md
@@ -1,6 +1,6 @@
 # Litestar Example
 
-This example shows how to integrate [Litestar](https://github.com/litestar-org/litestar/) with [openapipages](https://github.com/hasansezertasan/openapipages)
+This example shows how to integrate [Litestar](https://github.com/litestar-org/litestar/) with [openapipages](https://github.com/hasansezertasan/openapipages).
 
 ## How to run this example
 
@@ -14,6 +14,8 @@ cd openapipages/examples/litestar
 > This example uses [`uv`](https://docs.astral.sh/uv/) to manage its dependencies and developer environment.
 
 Run the example using `uv`, which will manage the environment and dependencies automatically:
+
+> The `include_in_schema` parameter is set to `False` in each endpoint to avoid including these endpoints in the OpenAPI Spec.
 
 ```shell
 uv run main.py


### PR DESCRIPTION
## Summary by Sourcery

Streamline documentation by replacing the inline Litestar usage snippet in the main README with a link to the dedicated example and refining the example README files with a note on the `include_in_schema` parameter and punctuation fixes.

Documentation:
- Redirect the Litestar usage section in the main README to the dedicated example file
- Add a note in the Litestar example README about setting `include_in_schema=False` to exclude endpoints from the OpenAPI spec
- Fix punctuation in the introductory sentences of both the Litestar and FastAPI example READMEs