### PR TITLE
chore(release-drafter): enhance configuration with new templates and autolabeler rules

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -54,7 +54,7 @@ def root() -> Dict[str, str]:
 @app.get("/redoc", response_class=HTMLResponse, include_in_schema=False)
 def get_redoc() -> str:
     """Redoc."""
-    0 / 0
+    0/0  # This will raise a ZeroDivisionError
     return ReDoc(title="ReDoc").render()
 
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,83 +1,29 @@
 ---
-name-template: '$RESOLVED_VERSION 🌈'
-tag-template: '$RESOLVED_VERSION'
+# Configuration for Release Drafter: https://github.com/release-drafter/release-drafter
+name-template: '$NEXT_PATCH_VERSION 🌈'
+tag-template: '$NEXT_PATCH_VERSION'
 template: |
-  # What's Changed
+  # :mega: openapipages $NEXT_PATCH_VERSION released!
+
+  We are pleased to announce the release of openapipages $NEXT_PATCH_VERSION.
+
+  ## :green_book: What’s Changed
 
   $CHANGES
 
-  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+  ## :bow: Credits
 
-change-template: '- $TITLE by @$AUTHOR in #$NUMBER'
+  Special thanks to the following contributors who helped with this release: $CONTRIBUTORS
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION
+
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
 no-changes-template: '- No changes'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 prerelease-identifier: 'rc'
 exclude-contributors:
   - 'dependabot'
   - 'pre-commit-ci'
   - 'renovate'
-
-categories:
-  - title: '💥 Breaking'
-    label: 'breaking'
-  - title: '🚀 Features'
-    labels:
-      - 'feature'
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
-  - title: '🧰 Maintenance'
-    label: 'maintenance'
-  - title: '📜 Documentation'
-    label: 'docs'
-  - title: '🔧 Other changes'
-    label: 'other'
-  - title: '⬆️ Dependencies'
-    collapse-after: 3
-    labels:
-      - 'dependencies'
-autolabeler:
-  - label: 'chore'
-    files:
-      - '*.md'
-    branch:
-      - '/docs{0,1}\/.+/'
-  - label: 'bug'
-    branch:
-      - '/fix\/.+/'
-    title:
-      - '/fix/i'
-  - label: 'enhancement'
-    branch:
-      - '/feature\/.+/'
-    body:
-      - '/JIRA-[0-9]{1,4}/'
-  - label: 'dependencies'
-    title:
-      - '/chore\(deps\)/i'
-  - label: 'github_actions'
-    files:
-      - '.github/workflows/*.yml'
-version-resolver:
-  major:
-    labels:
-      - 'major'
-      - 'breaking'
-  minor:
-    labels:
-      - 'minor'
-      - 'feature'
-  patch:
-    labels:
-      - 'patch'
-      - 'bug'
-      - 'maintenance'
-      - 'docs'
-      - 'dependencies'
-      - 'security'
-  default: patch
 exclude-labels:
   - 'skip-changelog'
+  - 'invalid'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -9,10 +9,13 @@ template: |
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 
 change-template: '- $TITLE by @$AUTHOR in #$NUMBER'
+no-changes-template: '- No changes'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+prerelease-identifier: 'rc'
 exclude-contributors:
   - 'dependabot'
   - 'pre-commit-ci'
+  - 'renovate'
 
 categories:
   - title: '💥 Breaking'
@@ -36,8 +39,28 @@ categories:
     collapse-after: 3
     labels:
       - 'dependencies'
-
-
+autolabeler:
+  - label: 'chore'
+    files:
+      - '*.md'
+    branch:
+      - '/docs{0,1}\/.+/'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'enhancement'
+    branch:
+      - '/feature\/.+/'
+    body:
+      - '/JIRA-[0-9]{1,4}/'
+  - label: 'dependencies'
+    title:
+      - '/chore\(deps\)/i'
+  - label: 'github_actions'
+    files:
+      - '.github/workflows/*.yml'
 version-resolver:
   major:
     labels:
@@ -56,7 +79,5 @@ version-resolver:
       - 'dependencies'
       - 'security'
   default: patch
-
-
 exclude-labels:
   - 'skip-changelog'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,6 +9,8 @@ on:
     types: [opened, reopened, synchronize]
   pull_request_target:
     types: [opened, reopened, synchronize]
+permissions:
+  contents: read
 jobs:
   update_release_draft:
     permissions:


### PR DESCRIPTION
## Summary by Sourcery

Enhance the Release Drafter configuration with additional templates, contributor filters, and automated labeling rules.

Enhancements:
- Add a no-changes template and prerelease identifier for draft releases
- Exclude Renovate from the list of release contributors
- Define autolabeler rules to automatically assign labels for chore (docs), bug fixes, enhancements (with JIRA tags), dependency updates, and GitHub Actions workflow changes

CI:
- Update .github/release-drafter.yml to refine release note formatting and labeling behavior