### PR TITLE
refactor(tests): update AsyncClient usage to utilize ASGITransport for all test files

### DIFF
--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1,13 +1,13 @@
 import pytest
 from fastapi import status
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 from tests.main import app
 
 
 @pytest.mark.asyncio
 async def test_elements() -> None:
-    async with AsyncClient(app=app, base_url="http://testserver/") as client:
+    async with AsyncClient(transport=ASGITransport(app), base_url="http://testserver/") as client:
         response = await client.get("/elements")
         assert response.status_code == status.HTTP_200_OK, response.text
         assert response.headers["content-type"] == "text/html; charset=utf-8"

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -7,7 +7,9 @@ from tests.main import app
 
 @pytest.mark.asyncio
 async def test_elements() -> None:
-    async with AsyncClient(transport=ASGITransport(app), base_url="http://testserver/") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app), base_url="http://testserver/"
+    ) as client:
         response = await client.get("/elements")
         assert response.status_code == status.HTTP_200_OK, response.text
         assert response.headers["content-type"] == "text/html; charset=utf-8"

--- a/tests/test_rapidoc.py
+++ b/tests/test_rapidoc.py
@@ -1,13 +1,13 @@
 import pytest
 from fastapi import status
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 from tests.main import app
 
 
 @pytest.mark.asyncio
 async def test_rapidoc() -> None:
-    async with AsyncClient(app=app, base_url="http://testserver/") as client:
+    async with AsyncClient(transport=ASGITransport(app), base_url="http://testserver/") as client:
         response = await client.get("/rapidoc")
         assert response.status_code == status.HTTP_200_OK, response.text
         assert response.headers["content-type"] == "text/html; charset=utf-8"

--- a/tests/test_rapidoc.py
+++ b/tests/test_rapidoc.py
@@ -7,7 +7,9 @@ from tests.main import app
 
 @pytest.mark.asyncio
 async def test_rapidoc() -> None:
-    async with AsyncClient(transport=ASGITransport(app), base_url="http://testserver/") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app), base_url="http://testserver/"
+    ) as client:
         response = await client.get("/rapidoc")
         assert response.status_code == status.HTTP_200_OK, response.text
         assert response.headers["content-type"] == "text/html; charset=utf-8"

--- a/tests/test_redoc.py
+++ b/tests/test_redoc.py
@@ -8,7 +8,9 @@ from tests.main import app
 @pytest.mark.asyncio
 async def test_redoc_plain() -> None:
     # Copy of  https://github.com/tiangolo/fastapi/blob/be876902554a0bd886167de144f0d593ed2e6ad7/tests/test_application.py#L42-L46
-    async with AsyncClient(transport=ASGITransport(app), base_url="http://testserver/") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app), base_url="http://testserver/"
+    ) as client:
         response = await client.get("/redoc-plain")
         assert response.status_code == status.HTTP_200_OK, response.text
         assert response.headers["content-type"] == "text/html; charset=utf-8"
@@ -19,7 +21,9 @@ async def test_redoc_plain() -> None:
 @pytest.mark.asyncio
 async def test_redoc_custom() -> None:
     # Copy of  https://github.com/tiangolo/fastapi/blob/be876902554a0bd886167de144f0d593ed2e6ad7/tests/test_tutorial/test_custom_docs_ui/test_tutorial001.py#L35-L38
-    async with AsyncClient(transport=ASGITransport(app), base_url="http://testserver/") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app), base_url="http://testserver/"
+    ) as client:
         response = await client.get("/redoc-custom")
         assert response.status_code == status.HTTP_200_OK, response.text
         assert (

--- a/tests/test_redoc.py
+++ b/tests/test_redoc.py
@@ -1,6 +1,6 @@
 import pytest
 from fastapi import status
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 from tests.main import app
 
@@ -8,7 +8,7 @@ from tests.main import app
 @pytest.mark.asyncio
 async def test_redoc_plain() -> None:
     # Copy of  https://github.com/tiangolo/fastapi/blob/be876902554a0bd886167de144f0d593ed2e6ad7/tests/test_application.py#L42-L46
-    async with AsyncClient(app=app, base_url="http://testserver/") as client:
+    async with AsyncClient(transport=ASGITransport(app), base_url="http://testserver/") as client:
         response = await client.get("/redoc-plain")
         assert response.status_code == status.HTTP_200_OK, response.text
         assert response.headers["content-type"] == "text/html; charset=utf-8"
@@ -19,7 +19,7 @@ async def test_redoc_plain() -> None:
 @pytest.mark.asyncio
 async def test_redoc_custom() -> None:
     # Copy of  https://github.com/tiangolo/fastapi/blob/be876902554a0bd886167de144f0d593ed2e6ad7/tests/test_tutorial/test_custom_docs_ui/test_tutorial001.py#L35-L38
-    async with AsyncClient(app=app, base_url="http://testserver/") as client:
+    async with AsyncClient(transport=ASGITransport(app), base_url="http://testserver/") as client:
         response = await client.get("/redoc-custom")
         assert response.status_code == status.HTTP_200_OK, response.text
         assert (

--- a/tests/test_scalar.py
+++ b/tests/test_scalar.py
@@ -7,7 +7,9 @@ from tests.main import app
 
 @pytest.mark.asyncio
 async def test_scalar_plain() -> None:
-    async with AsyncClient(transport=ASGITransport(app), base_url="http://testserver/") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app), base_url="http://testserver/"
+    ) as client:
         response = await client.get("/scalar-plain")
         assert response.status_code == status.HTTP_200_OK, response.text
         assert response.headers["content-type"] == "text/html; charset=utf-8"
@@ -16,7 +18,9 @@ async def test_scalar_plain() -> None:
 
 @pytest.mark.asyncio
 async def test_scalar_custom() -> None:
-    async with AsyncClient(transport=ASGITransport(app), base_url="http://testserver/") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app), base_url="http://testserver/"
+    ) as client:
         response = await client.get("/scalar-custom")
         assert response.status_code == status.HTTP_200_OK, response.text
         assert "https://cdn.jsdelivr.net/npm/@scalar/api-reference" in response.text

--- a/tests/test_scalar.py
+++ b/tests/test_scalar.py
@@ -1,13 +1,13 @@
 import pytest
 from fastapi import status
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 from tests.main import app
 
 
 @pytest.mark.asyncio
 async def test_scalar_plain() -> None:
-    async with AsyncClient(app=app, base_url="http://testserver/") as client:
+    async with AsyncClient(transport=ASGITransport(app), base_url="http://testserver/") as client:
         response = await client.get("/scalar-plain")
         assert response.status_code == status.HTTP_200_OK, response.text
         assert response.headers["content-type"] == "text/html; charset=utf-8"
@@ -16,7 +16,7 @@ async def test_scalar_plain() -> None:
 
 @pytest.mark.asyncio
 async def test_scalar_custom() -> None:
-    async with AsyncClient(app=app, base_url="http://testserver/") as client:
+    async with AsyncClient(transport=ASGITransport(app), base_url="http://testserver/") as client:
         response = await client.get("/scalar-custom")
         assert response.status_code == status.HTTP_200_OK, response.text
         assert "https://cdn.jsdelivr.net/npm/@scalar/api-reference" in response.text

--- a/tests/test_swaggerui.py
+++ b/tests/test_swaggerui.py
@@ -8,7 +8,9 @@ from tests.main import app
 @pytest.mark.asyncio
 async def test_swagger_ui_plain() -> None:
     # Copy of https://github.com/tiangolo/fastapi/blob/be876902554a0bd886167de144f0d593ed2e6ad7/tests/test_application.py#L24-L32
-    async with AsyncClient(transport=ASGITransport(app), base_url="http://testserver/") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app), base_url="http://testserver/"
+    ) as client:
         response = await client.get("/swaggerui-plain")
         assert response.status_code == status.HTTP_200_OK, response.text
         assert response.headers["content-type"] == "text/html; charset=utf-8"
@@ -22,7 +24,9 @@ async def test_swagger_ui_plain() -> None:
 @pytest.mark.asyncio
 async def test_swagger_ui_custom() -> None:
     # Copy of https://github.com/tiangolo/fastapi/blob/be876902554a0bd886167de144f0d593ed2e6ad7/tests/test_tutorial/test_custom_docs_ui/test_tutorial001.py#L20-L26
-    async with AsyncClient(transport=ASGITransport(app), base_url="http://testserver/") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app), base_url="http://testserver/"
+    ) as client:
         response = await client.get("/swaggerui-custom")
         assert response.status_code == status.HTTP_200_OK, response.text
         assert (

--- a/tests/test_swaggerui.py
+++ b/tests/test_swaggerui.py
@@ -1,6 +1,6 @@
 import pytest
 from fastapi import status
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 from tests.main import app
 
@@ -8,7 +8,7 @@ from tests.main import app
 @pytest.mark.asyncio
 async def test_swagger_ui_plain() -> None:
     # Copy of https://github.com/tiangolo/fastapi/blob/be876902554a0bd886167de144f0d593ed2e6ad7/tests/test_application.py#L24-L32
-    async with AsyncClient(app=app, base_url="http://testserver/") as client:
+    async with AsyncClient(transport=ASGITransport(app), base_url="http://testserver/") as client:
         response = await client.get("/swaggerui-plain")
         assert response.status_code == status.HTTP_200_OK, response.text
         assert response.headers["content-type"] == "text/html; charset=utf-8"
@@ -22,7 +22,7 @@ async def test_swagger_ui_plain() -> None:
 @pytest.mark.asyncio
 async def test_swagger_ui_custom() -> None:
     # Copy of https://github.com/tiangolo/fastapi/blob/be876902554a0bd886167de144f0d593ed2e6ad7/tests/test_tutorial/test_custom_docs_ui/test_tutorial001.py#L20-L26
-    async with AsyncClient(app=app, base_url="http://testserver/") as client:
+    async with AsyncClient(transport=ASGITransport(app), base_url="http://testserver/") as client:
         response = await client.get("/swaggerui-custom")
         assert response.status_code == status.HTTP_200_OK, response.text
         assert (


### PR DESCRIPTION
## Summary by Sourcery

Refactor tests to initialize HTTPX AsyncClient with ASGITransport instead of passing the FastAPI app directly

Tests:
- Update AsyncClient instantiation in test_scalar, test_elements, test_rapidoc, test_redoc, and test_swaggerui to use transport=ASGITransport(app)
- Add ASGITransport import to all affected test modules for consistent HTTPX usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test setup for multiple endpoints to use a new method for initializing the test client. No changes to test logic or assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->