### PR TITLE
fix(cd): add permissions for GitHub Release in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,7 @@ jobs:
     name: Publish on PyPI
     permissions:
       id-token: write  # IMPORTANT: Mandatory for Trusted Publishing (gh-action-pypi-publish)
+      contents: write  # IMPORTANT: Mandatory for GitHub Release
     # Specifying a GitHub environment is optional, but strongly encouraged
     environment:
       name: publish


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add contents: write permission to the cd.yml GitHub Actions workflow for GitHub Release