### PR TITLE
fix(coverage): reconfigure the coverage, pytest and hatch envs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/release-drafter/release-drafter/refs/heads/master/schema.json
 # Configuration for Release Drafter: https://github.com/release-drafter/release-drafter
 name-template: '$RESOLVED_VERSION 🌈'
 tag-template: '$RESOLVED_VERSION'
@@ -30,3 +31,35 @@ replacers:
   # https://github.com/release-drafter/release-drafter/issues/569#issuecomment-645942909
   - search: '/(?:and )?@(pre-commit-ci|dependabot|renovate)(?:\[bot\])?,?/g'
     replace: ''
+autolabeler:
+  - label: 'documentation'
+    files:
+      - '*.md'
+      - 'docs/**'
+    branch:
+      - '/docs{0,1}\/.+/'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/^fix/i'
+  - label: 'enhancement'
+    branch:
+      - '/feature\/.+/'
+    body:
+      - '/JIRA-[0-9]{1,4}/'
+    title:
+      - '/^feat/i'
+  - label: 'dependencies'
+    title:
+      - '/^chore\(deps\)/i'
+      - '/^fix\(deps\)/i'
+      - '/^chore:\s*bump/i'
+  - label: 'github_actions'
+    files:
+      - '.github/workflows/*.yml'
+  - label: 'chore'
+    branch:
+      - '/docs{0,1}\/.+/'
+    title:
+      - '/^chore/i'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Upload coverage files
       uses: actions/upload-artifact@v4.6.2
       with:
-        name: coverage-${{ matrix.python-version }}
+        name: coverage-${{ matrix.os }}-${{ matrix.python-version }}
         path: .coverage*
         retention-days: 1
         include-hidden-files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,12 @@ jobs:
     - name: Run tests
       run: hatch run +py=${{ matrix.python-version }} test:test
     - name: Let's see what's going on
+      shell: bash
       run: ls -la .
     - name: Enforce coverage
       run: hatch run +py=${{ matrix.python-version }} test:cov
     - name: Let's see what's going on
+      shell: bash
       run: ls -la .
     - name: Upload Coverage
       uses: codecov/codecov-action@v5.4.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     name: Python ${{ matrix.python-version }} on ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -32,8 +33,14 @@ jobs:
     - name: Install Hatch
       run: pip install --upgrade hatch
     - name: Run static analysis
-      run: hatch run static-analysis:all
+      if: matrix.os == 'ubuntu-latest' && (matrix.python-version == '3.8' || matrix.python-version == '3.13')
+      run: |
+          hatch run +py=${{ matrix.python-version }} test:style
     - name: Run tests
-      run: hatch test --python ${{ matrix.python-version }} --cover --randomize --parallel --retries 2 --retry-delay 1
-    - name: Upload coverage reports to Codecov
+      run: hatch run +py=${{ matrix.python-version }} test:test
+    - name: Enforce coverage
+      run: hatch run test:cov
+    - name: Upload Coverage
       uses: codecov/codecov-action@v5.4.3
+      with:
+        files: coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
 jobs:
-  run:
+  tests:
     name: Python ${{ matrix.python-version }} on ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
@@ -46,7 +46,45 @@ jobs:
     - name: Let's see what's going on
       shell: bash
       run: ls -la .
-    - name: Upload Coverage
-      uses: codecov/codecov-action@v5.4.3
+    - name: Upload coverage files
+      uses: actions/upload-artifact@v4.6.2
       with:
-        files: coverage.xml
+        name: coverage-${{ matrix.python-version }}
+        path: .coverage*
+        retention-days: 1
+        include-hidden-files: true
+  coverage:
+    needs:
+      - tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: '.python-version'
+      - name: Setup uv
+        id: setup-uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Restore cache
+        if: steps.setup-uv.outputs.cache-hit == 'true'
+        run: echo "Cache was restored"
+      - name: Download coverage files
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage*
+          merge-multiple: true
+      - name: Coverage Report
+        run: |
+          uvx coverage combine
+          uvx coverage report
+          uvx coverage xml
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v5.4.3
+        with:
+          files: coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,6 @@ jobs:
     - name: Let's see what's going on
       shell: bash
       run: ls -la .
-    - name: Enforce coverage
-      run: hatch run +py=${{ matrix.python-version }} test:cov
-    - name: Let's see what's going on
-      shell: bash
-      run: ls -la .
     - name: Upload coverage files
       uses: actions/upload-artifact@v4.6.2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,12 @@ jobs:
           hatch run +py=${{ matrix.python-version }} test:style
     - name: Run tests
       run: hatch run +py=${{ matrix.python-version }} test:test
+    - name: Let's see what's going on
+      run: ls -la .
     - name: Enforce coverage
-      run: hatch run test:cov
+      run: hatch run +py=${{ matrix.python-version }} test:cov
+    - name: Let's see what's going on
+      run: ls -la .
     - name: Upload Coverage
       uses: codecov/codecov-action@v5.4.3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
         retention-days: 1
         include-hidden-files: true
   coverage:
+    name: Coverage Report
     needs:
       - tests
     runs-on: ubuntu-latest
@@ -79,11 +80,13 @@ jobs:
         with:
           pattern: coverage*
           merge-multiple: true
+      - name: Install coverage
+        run: uv tool install coverage[toml]
       - name: Coverage Report
         run: |
-          uvx coverage combine
-          uvx coverage report
-          uvx coverage xml
+          uv tool run coverage combine
+          uv tool run coverage report
+          uv tool run coverage xml
       - name: Upload Coverage
         uses: codecov/codecov-action@v5.4.3
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Open API Pages
 
 [![CI](https://github.com/hasansezertasan/openapipages/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/hasansezertasan/openapipages/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/codecov/c/github/hasansezertasan/openapipages)](https://codecov.io/gh/hasansezertasan/openapipages)
 [![PyPI - Version](https://img.shields.io/pypi/v/openapipages.svg)](https://pypi.org/project/openapipages)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/openapipages.svg)](https://pypi.org/project/openapipages)
 [![License - MIT](https://img.shields.io/github/license/hasansezertasan/openapipages.svg)](https://opensource.org/licenses/MIT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,32 +94,49 @@ extra-dependencies = [
 pre = "pre-commit run --all-files --hook-stage manual --show-diff-on-failure"
 
 
-[tool.hatch.envs.static-analysis]
+[tool.hatch.envs.test]
+installer = "uv"
 dependencies = [
-  "ruff==0.12.7",
-  "mypy>=1.0.0",
-  "codespell==2.4.1",
-  "validate-pyproject[toml]>=0.24.1",
-  "vulture>=2.14",
-  "typos>=1.34.0",
-  "taplo>=0.9.3",
+    # Based on hatch-test
+    "coverage-enable-subprocess==1.0",
+    "coverage[toml]~=7.4",
+    "pytest~=8.1",
+    "pytest-mock~=3.12",
+    "pytest-randomly~=3.15",
+    "pytest-rerunfailures~=14.0",
+    "pytest-xdist[psutil]~=3.5",
+    # Custom for testing
+    "pytest-asyncio>=0.14.0",
+    "httpx>=0.23.3,<0.27.0",
+    "fastapi>=0.63.0,<0.110.0",
+    # Custom for Style and Static Analysis
+    "ruff==0.12.7",
+    "mypy>=1.0.0",
+    "codespell==2.4.1",
+    "validate-pyproject[toml]>=0.24.1",
+    "vulture>=2.14",
+    "typos>=1.34.0",
+    "taplo>=0.9.3",
 ]
 
 
-[tool.hatch.envs.static-analysis.scripts]
-format = "ruff format"
-lint = "ruff check"
-check = "mypy --install-types --non-interactive {args:src/openapipages tests}"
-spelling = "codespell ."
-all = ["spelling", "check", "lint", "format"]
-
-
-[tool.hatch.envs.hatch-test]
-extra-dependencies = [
-  "pytest-asyncio>=0.14.0",
-  "httpx>=0.23.3,<0.27.0",
-  "fastapi>=0.63.0,<0.110.0",
+[tool.hatch.envs.test.scripts]
+test = "coverage run -m pytest tests"
+cov = [
+  "coverage combine",
+  "coverage report",
+  "coverage xml",
 ]
+style = [
+  "codespell .",
+  "validate-pyproject pyproject.toml",
+  "ruff check",
+  "ruff format",
+  "mypy --install-types --non-interactive {args:src/openapipages tests}",
+]
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.13", "3.12", "3.11", "3.10", "3.9", "3.8"]
 
 
 [tool.ruff]
@@ -208,6 +225,11 @@ disallow_untyped_decorators = false
 ignore-words-list = "Connexion, connexion"
 
 
+[tool.pytest.ini_options]
+asyncio_mode="auto"
+asyncio_default_fixture_loop_scope="function"
+
+
 [tool.coverage.run]
 source_pkgs = ["openapipages", "tests"]
 branch = true
@@ -223,8 +245,11 @@ tests = ["tests", "*/openapipages/tests"]
 
 
 [tool.coverage.report]
+fail_under = 99
+show_missing = true
+skip_covered = true
 exclude_lines = [
-  "no cov",
+  "pragma: no cover",
   "if __name__ == .__main__.:",
   "if TYPE_CHECKING:",
 ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,10 @@
 {
+  // Take a look at: https://github.com/astral-sh/ruff/blob/main/.github/renovate.json5
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": true,
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "labels": ["internal"],
+  "semanticCommits": "enabled"
 }

--- a/src/openapipages/base.py
+++ b/src/openapipages/base.py
@@ -73,14 +73,14 @@ class Base:
         Returns:
             str: The generated HTML response as a string.
         """
-        html_template = self.get_html_template()
+        html_template = self.get_html_template()  # pragma: no cover
         return html_template.format(
             title=self.title,
             favicon_url=self.favicon_url,
             head_css_str=self.get_head_css_str(),
             head_js_str=self.get_head_js_str(),
             tail_js_str=self.get_tail_js_str(),
-        )
+        )  # pragma: no cover
 
     def get_html_template(self) -> str:
         """Return the HTML template for the alternative API docs."""
@@ -97,7 +97,7 @@ class Base:
                 {tail_js_str}
             </body>
         </html>
-        """
+        """  # pragma: no cover
 
     def get_tail_js_str(self) -> str:
         """Return the string of JavaScript URLs that should be loaded at the end of the `<body>` tag."""

--- a/src/openapipages/redoc.py
+++ b/src/openapipages/redoc.py
@@ -63,9 +63,9 @@ class ReDoc(Base):
         self.tail_js_urls.insert(0, self.js_url)
         google_fonts_str = ""
         if self.with_google_fonts:
-            google_fonts_str = """<link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">"""
+            google_fonts_str = """<link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">"""  # pragma: no cover
 
-        current_redoc_ui_parameters = default_parameters.copy()
+        current_redoc_ui_parameters = default_parameters.copy()  # pragma: no cover
         current_redoc_ui_parameters.update(self.ui_parameters or {})
 
         html_template = self.get_html_template()

--- a/src/openapipages/swaggerui.py
+++ b/src/openapipages/swaggerui.py
@@ -102,7 +102,9 @@ class SwaggerUI(Base):
             current_swagger_ui_parameters.update(self.swagger_ui_parameters)
         current_swagger_ui_presets = default_parameters_presets.copy()
         if self.swagger_ui_presets:
-            current_swagger_ui_presets.extend(self.swagger_ui_presets)
+            current_swagger_ui_presets.extend(
+                self.swagger_ui_presets
+            )  # pragma: no cover
         presets = ", ".join(current_swagger_ui_presets)
         html_swagger_ui_parameters = "".join([
             f"{json.dumps(key)}: {json.dumps(value)},"

--- a/tests/main.py
+++ b/tests/main.py
@@ -9,7 +9,7 @@ app = FastAPI()
 
 @app.get("/")
 def root() -> Dict[str, str]:
-    return {"Hello": "World"}
+    return {"Hello": "World"}  # pragma: no cover
 
 
 @app.get("/swaggerui-plain", response_class=HTMLResponse, include_in_schema=False)

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -8,7 +8,8 @@ from tests.main import app
 @pytest.mark.asyncio
 async def test_elements() -> None:
     async with AsyncClient(
-        transport=ASGITransport(app), base_url="http://testserver/"
+        transport=ASGITransport(app),  # type: ignore[arg-type]
+        base_url="http://testserver/",
     ) as client:
         response = await client.get("/elements")
         assert response.status_code == status.HTTP_200_OK, response.text

--- a/tests/test_rapidoc.py
+++ b/tests/test_rapidoc.py
@@ -8,7 +8,8 @@ from tests.main import app
 @pytest.mark.asyncio
 async def test_rapidoc() -> None:
     async with AsyncClient(
-        transport=ASGITransport(app), base_url="http://testserver/"
+        transport=ASGITransport(app),  # type: ignore[arg-type]
+        base_url="http://testserver/",
     ) as client:
         response = await client.get("/rapidoc")
         assert response.status_code == status.HTTP_200_OK, response.text

--- a/tests/test_redoc.py
+++ b/tests/test_redoc.py
@@ -9,7 +9,8 @@ from tests.main import app
 async def test_redoc_plain() -> None:
     # Copy of  https://github.com/tiangolo/fastapi/blob/be876902554a0bd886167de144f0d593ed2e6ad7/tests/test_application.py#L42-L46
     async with AsyncClient(
-        transport=ASGITransport(app), base_url="http://testserver/"
+        transport=ASGITransport(app),  # type: ignore[arg-type]
+        base_url="http://testserver/",
     ) as client:
         response = await client.get("/redoc-plain")
         assert response.status_code == status.HTTP_200_OK, response.text
@@ -22,7 +23,8 @@ async def test_redoc_plain() -> None:
 async def test_redoc_custom() -> None:
     # Copy of  https://github.com/tiangolo/fastapi/blob/be876902554a0bd886167de144f0d593ed2e6ad7/tests/test_tutorial/test_custom_docs_ui/test_tutorial001.py#L35-L38
     async with AsyncClient(
-        transport=ASGITransport(app), base_url="http://testserver/"
+        transport=ASGITransport(app),  # type: ignore[arg-type]
+        base_url="http://testserver/",
     ) as client:
         response = await client.get("/redoc-custom")
         assert response.status_code == status.HTTP_200_OK, response.text

--- a/tests/test_scalar.py
+++ b/tests/test_scalar.py
@@ -8,7 +8,8 @@ from tests.main import app
 @pytest.mark.asyncio
 async def test_scalar_plain() -> None:
     async with AsyncClient(
-        transport=ASGITransport(app), base_url="http://testserver/"
+        transport=ASGITransport(app),  # type: ignore[arg-type]
+        base_url="http://testserver/",
     ) as client:
         response = await client.get("/scalar-plain")
         assert response.status_code == status.HTTP_200_OK, response.text
@@ -19,7 +20,8 @@ async def test_scalar_plain() -> None:
 @pytest.mark.asyncio
 async def test_scalar_custom() -> None:
     async with AsyncClient(
-        transport=ASGITransport(app), base_url="http://testserver/"
+        transport=ASGITransport(app),  # type: ignore[arg-type]
+        base_url="http://testserver/",
     ) as client:
         response = await client.get("/scalar-custom")
         assert response.status_code == status.HTTP_200_OK, response.text

--- a/tests/test_swaggerui.py
+++ b/tests/test_swaggerui.py
@@ -9,7 +9,8 @@ from tests.main import app
 async def test_swagger_ui_plain() -> None:
     # Copy of https://github.com/tiangolo/fastapi/blob/be876902554a0bd886167de144f0d593ed2e6ad7/tests/test_application.py#L24-L32
     async with AsyncClient(
-        transport=ASGITransport(app), base_url="http://testserver/"
+        transport=ASGITransport(app),  # type: ignore[arg-type]
+        base_url="http://testserver/",
     ) as client:
         response = await client.get("/swaggerui-plain")
         assert response.status_code == status.HTTP_200_OK, response.text
@@ -25,7 +26,8 @@ async def test_swagger_ui_plain() -> None:
 async def test_swagger_ui_custom() -> None:
     # Copy of https://github.com/tiangolo/fastapi/blob/be876902554a0bd886167de144f0d593ed2e6ad7/tests/test_tutorial/test_custom_docs_ui/test_tutorial001.py#L20-L26
     async with AsyncClient(
-        transport=ASGITransport(app), base_url="http://testserver/"
+        transport=ASGITransport(app),  # type: ignore[arg-type]
+        base_url="http://testserver/",
     ) as client:
         response = await client.get("/swaggerui-custom")
         assert response.status_code == status.HTTP_200_OK, response.text


### PR DESCRIPTION
## Summary by Sourcery

Reconfigure the project's test, coverage, and static analysis setup by merging Hatch environments, enforcing coverage thresholds, adjusting pytest and coverage settings, and updating CI and release-drafter workflows

Enhancements:
- Consolidate static-analysis and test environments into a unified Hatch 'test' env with dependencies for testing, coverage, and style tools
- Define Hatch scripts for running tests, coverage reporting, and style checks, and configure a Python version matrix
- Update coverage settings to enforce a 99% threshold, show missing lines, and recognize 'pragma: no cover'
- Add pytest asyncio configuration in pytest.ini
- Annotate code and tests with coverage pragmas and suppress type errors in AsyncClient transport parameters

CI:
- Add timeout, style checks, test execution, coverage enforcement, and matrix-based runs to GitHub Actions CI workflow
- Upload coverage.xml to Codecov using the Codecov action

Documentation:
- Add YAML schema comment and autolabeler rules to release-drafter configuration