### PR TITLE
ci: apply current prek formatting

### DIFF
--- a/.github/workflows/check-prek.yml
+++ b/.github/workflows/check-prek.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           enable-cache: true
       # basedpyright needs project deps importable to resolve third-party

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -4,7 +4,7 @@
 # [tool.uv.sources]
 # openapipages = { path = "../../", editable = true }
 # ///
-# ruff: noqa: S104
+# ruff: file-ignore[hardcoded-bind-all-interfaces]
 
 import uvicorn
 from fastapi import FastAPI

--- a/examples/litestar/main.py
+++ b/examples/litestar/main.py
@@ -1,4 +1,4 @@
-# ruff: noqa: RUF029, S104
+# ruff: file-ignore[unused-async, hardcoded-bind-all-interfaces]
 
 from typing import Any
 


### PR DESCRIPTION
## Summary
- apply the current yamlfmt spacing normalization
- migrate Ruff file-level suppressions to the current `file-ignore` syntax

This unblocks the pending prek, Ruff, and related tooling-update PRs.

## Verification
- `uv run --with prek prek run --all-files --show-diff-on-failure` ✅
- Re-ran the same command after the generated changes: ✅